### PR TITLE
fix: ensure Cell#value supports string[][]

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -139,7 +139,7 @@ declare namespace XlsxPopulate {
     style(styles: {[key: string]: any}): Cell
     style(style: Style): Cell
     value(): string | boolean | number | Date | undefined
-    value(value: string | boolean | number | null | undefined): Cell
+    value(value: string | boolean | number | string[][] | null | undefined): Cell
     value(): Range
     workbook(): Workbook
     addHorizontalPageBreak(): Cell


### PR DESCRIPTION
In https://github.com/dtjohnson/xlsx-populate#readme it mentions that
> ...you can set the values in a range with only the top-left cell in the range:
```javascript
workbook.sheet(0).cell("A1").value([
    [1, 2, 3],
    [4, 5, 6],
    [7, 8, 9]
]);
```
This is also implemented in https://github.com/dtjohnson/xlsx-populate/blob/master/lib/Cell.js#L389
The current type definition does not seem to support this type of argument.